### PR TITLE
Fixed Combusion

### DIFF
--- a/src/com/jedk1/jedcore/ability/firebending/Combustion.java
+++ b/src/com/jedk1/jedcore/ability/firebending/Combustion.java
@@ -358,7 +358,7 @@ public class Combustion extends CombustionAbility implements AddonAbility {
 				Sphere collider = new Sphere(location.toVector(), entityCollisionRadius);
 
 				boolean hit = CollisionDetector.checkEntityCollisions(player, collider, (entity) -> {
-					location = entity.getLocation();
+					location = entity.getLocation().add(0, 0.1, 0);
 					state = new CombustState(location);
 					return true;
 				});


### PR DESCRIPTION
Added 0.1 to knockback, which stops the slab from normalizing to a zero vector

## Summary
What does this PR do?
Fixed issues where combustion normalizes a player's velocity to Inf
## Details
Anything else worth mentioning.
nah